### PR TITLE
Remove the 'android' type default value

### DIFF
--- a/src/components/SmartBanner.js
+++ b/src/components/SmartBanner.js
@@ -70,7 +70,7 @@ class SmartBanner extends Component {
   }
 
   setType(deviceType) {
-    let type = 'android';
+    let type;
 
     if (isClient) {
       const agent = ua(window.navigator.userAgent);


### PR DESCRIPTION
When I use react-smartbanner on all browsers on my laptop, I can see the banner because the default type is "android". Why not use an undefined default value to hide the smart banner in desktop (and all unknown cases) ?