### PR TITLE
fix cookie expiration

### DIFF
--- a/src/components/SmartBanner.js
+++ b/src/components/SmartBanner.js
@@ -6,6 +6,14 @@ const isClient = typeof window !== 'undefined';
 let ua;
 let cookie;
 
+const expiredDateInUTC = (additionalDays) => {
+  const expiredDate = new Date();
+
+  expiredDate.setDate(expiredDate.getDate() + additionalDays);
+
+  return expiredDate.toUTCString();
+};
+
 class SmartBanner extends Component {
   static propTypes = {
     daysHidden: PropTypes.number,
@@ -196,7 +204,7 @@ class SmartBanner extends Component {
     this.hide();
     cookie.set('smartbanner-closed', 'true', {
       path: '/',
-      expires: +new Date() + this.props.daysHidden * 1000 * 60 * 60 * 24,
+      expires: expiredDateInUTC(this.props.daysHidden),
     });
 
     if (this.props.onClose && typeof this.props.onClose === 'function') {
@@ -208,7 +216,7 @@ class SmartBanner extends Component {
     this.hide();
     cookie.set('smartbanner-installed', 'true', {
       path: '/',
-      expires: +new Date() + this.props.daysReminder * 1000 * 60 * 60 * 24,
+      expires: expiredDateInUTC(this.props.daysReminder),
     });
 
     if (this.props.onInstall && typeof this.props.onInstall === 'function') {

--- a/src/components/__tests__/SmartBanner.test.js
+++ b/src/components/__tests__/SmartBanner.test.js
@@ -113,7 +113,7 @@ describe('SmartBanner', function () { // eslint-disable-line func-names
       expect(window.document.querySelector('html').classList).not.toContain('smartbanner-show');
       expect(cookie.set).toBeCalledWith('smartbanner-closed', 'true', {
         path: '/',
-        expires: 1495756800000,
+        expires: 'Fri, 26 May 2017 00:00:00 GMT',
       });
       expect(spy).toHaveBeenCalled();
     });
@@ -132,7 +132,7 @@ describe('SmartBanner', function () { // eslint-disable-line func-names
       expect(window.document.querySelector('html').classList).not.toContain('smartbanner-show');
       expect(cookie.set).toBeCalledWith('smartbanner-installed', 'true', {
         path: '/',
-        expires: 1502236800000,
+        expires: 'Thu, 24 Aug 2017 00:00:00 GMT',
       });
       expect(spy).toHaveBeenCalled();
     });


### PR DESCRIPTION
Issue: Cookie expiration is always session, meaning the cookie is deleted every time the browser is closed.
Cause: Expired parameter need to receive a date string in UTC instead of timestamp
Solution: Create a function to convert additional days (`daysHidden` or `daysReminder`) to a UTC string