### PR TITLE
Allow button prop to accept anything that can be rendered

### DIFF
--- a/src/components/SmartBanner.js
+++ b/src/components/SmartBanner.js
@@ -19,7 +19,7 @@ class SmartBanner extends Component {
     daysHidden: PropTypes.number,
     daysReminder: PropTypes.number,
     appStoreLanguage: PropTypes.string,
-    button: PropTypes.string,
+    button: PropTypes.node,
     storeText: PropTypes.objectOf(PropTypes.string),
     price: PropTypes.objectOf(PropTypes.string),
     force: PropTypes.string,


### PR DESCRIPTION
This is to allow the button prop to accept anything that can be rendered: numbers, strings, elements or an array (or fragment) containing these types.

This will prevent failed prop type warnings in the scenario the developer would like to pass something like an element in rather than just a string.