### PR TITLE
remove root element class names after unmounting SmartBanner component

### DIFF
--- a/src/components/SmartBanner.js
+++ b/src/components/SmartBanner.js
@@ -106,6 +106,14 @@ class SmartBanner extends Component {
     }
   }
 
+  componentWillUnmount() {
+    const documentRoot = window.document.querySelector('html');
+
+    documentRoot.classList.remove('smartbanner-show');
+    documentRoot.classList.remove('smartbanner-margin-top');
+    documentRoot.classList.remove('smartbanner-margin-bottom');
+  }
+
   setType(deviceType) {
     let type;
 

--- a/src/components/__tests__/SmartBanner.test.js
+++ b/src/components/__tests__/SmartBanner.test.js
@@ -160,6 +160,15 @@ describe('SmartBanner', function () { // eslint-disable-line func-names
     expect(subject.state('type')).toBe('ios');
   });
 
+  it('should remove html class names on unload', () => {
+    const subject = this.makeSubject();
+
+    subject.unmount();
+    expect(window.document.querySelector('html').classList).not.toContain('smartbanner-show');
+    expect(window.document.querySelector('html').classList).not.toContain('smartbanner-margin-top');
+    expect(window.document.querySelector('html').classList).not.toContain('smartbanner-margin-bottom');
+  });
+
   describe('userAgent', () => {
     it('should change type to "ios" if we set iOS user agent', () => {
       window.navigator.__defineGetter__('userAgent', () => {

--- a/src/components/__tests__/__snapshots__/SmartBanner.test.js.snap
+++ b/src/components/__tests__/__snapshots__/SmartBanner.test.js.snap
@@ -1,21 +1,21 @@
 exports[`SmartBanner type snapshots should be matched the snapshot (android) 1`] = `
-"<div class=\"smartbanner smartbanner-android\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
+"<div class=\"smartbanner smartbanner-android smartbanner-top\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
       Free - In Google Play</div></div><div class=\"smartbanner-wrapper\"><a href=\"undefined\" class=\"smartbanner-button\"><span class=\"smartbanner-button-text\">View</span></a></div></div></div>"
 `;
 
 exports[`SmartBanner type snapshots should be matched the snapshot (ios) 1`] = `
-"<div class=\"smartbanner smartbanner-ios\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
+"<div class=\"smartbanner smartbanner-ios smartbanner-top\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
       Free - On the App Store</div></div><div class=\"smartbanner-wrapper\"><a href=\"undefined\" class=\"smartbanner-button\"><span class=\"smartbanner-button-text\">View</span></a></div></div></div>"
 `;
 
 exports[`SmartBanner type snapshots should be matched the snapshot (kindle) 1`] = `
-"<div class=\"smartbanner smartbanner-kindle\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
+"<div class=\"smartbanner smartbanner-kindle smartbanner-top\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
       Free - In the Amazon Appstore</div></div><div class=\"smartbanner-wrapper\"><a href=\"undefined\" class=\"smartbanner-button\"><span class=\"smartbanner-button-text\">View</span></a></div></div></div>"
 `;
 
 exports[`SmartBanner type snapshots should be matched the snapshot (no type) 1`] = `"<div></div>"`;
 
 exports[`SmartBanner type snapshots should be matched the snapshot (windows) 1`] = `
-"<div class=\"smartbanner smartbanner-windows\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
+"<div class=\"smartbanner smartbanner-windows smartbanner-top\"><div class=\"smartbanner-container\"><a class=\"smartbanner-close\">×</a><span class=\"smartbanner-icon\" style=\"background-image: url(undefined);\"></span><div class=\"smartbanner-info\"><div class=\"smartbanner-title\"></div><div class=\"smartbanner-author\"></div><div class=\"smartbanner-description\">
       Free - In Windows Store</div></div><div class=\"smartbanner-wrapper\"><a href=\"undefined\" class=\"smartbanner-button\"><span class=\"smartbanner-button-text\">View</span></a></div></div></div>"
 `;


### PR DESCRIPTION
I've noticed that the class names on the HTML tag are not getting removed from the DOM once the SmartBanner gets unmounted. This can lead to undesired effects if other styles depend on those class names. In my case I wanted to push another banner (cookie policy) below the SmartBanner, so I've used the `smartbanner-show` class as a sibling class in the css code. As I only display the SmartBanner under certain conditions and not on all pages, there is the possibility for it to get unmounted from the DOM. If that happens without the user interacting with it, the class names need to get removed from DOM manually.

I've used `element.classList.remove` with one parameter and repeated it for all the possible class names to not break it in IE11. A unit test has been added, too. For whatever reason I also had to update the snapshot file.