### PR TITLE
Fixed #46: Webpack UDM issue

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -42,6 +42,7 @@ module.exports = {
     publicPath: publicPath,
     library: 'SmartBanner',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
 
   externals: {


### PR DESCRIPTION
In v5.1.2, we upgraded webpack to v4, so we might get an error: `window is not defined` in SSR.
In webpack's issue, we found a workaround of this issue. (https://github.com/webpack/webpack/issues/6522#issuecomment-371120689)
